### PR TITLE
Update link to Rust repository

### DIFF
--- a/doc/compile-the-compiler.asciidoc
+++ b/doc/compile-the-compiler.asciidoc
@@ -45,7 +45,7 @@ Now, download the Rust compiler source code:
 
 [source,sh]
 ---------------------------------------------------------------
-% git clone http://github.com/mozilla/rust.git
+% git clone https://github.com/rust-lang/rust.git
 ---------------------------------------------------------------
 
 Add the Raspberry Pi tools to your shell's command search path:


### PR DESCRIPTION
The Git URL to the Rust repository was referring to the old repository + using HTTP. I've updated the link.